### PR TITLE
Enforce sorted imports

### DIFF
--- a/benches/bench_base.py
+++ b/benches/bench_base.py
@@ -9,7 +9,6 @@ from benches.utils import run_benchmark
 from benches.utils.data_generation import generate_base_data
 from cloud_resource_matcher.modules.base import base_module
 
-
 DEFAULT_PARAMS = {
     "cr_count": 1000,
     "cs_count": 1000,

--- a/benches/bench_complete.py
+++ b/benches/bench_complete.py
@@ -6,11 +6,10 @@ from optiframe.framework import InitializedOptimizer
 from pulp import LpMinimize
 
 from benches.utils import run_benchmark
-from benches.utils.data_generation import generate_network_data, generate_base_data
+from benches.utils.data_generation import generate_base_data, generate_network_data
 from cloud_resource_matcher.modules.base import base_module
 from cloud_resource_matcher.modules.multi_cloud import MultiCloudData, multi_cloud_module
 from cloud_resource_matcher.modules.network import network_module
-
 
 DEFAULT_PARAMS = {
     "cr_count": 500,

--- a/benches/bench_mini.py
+++ b/benches/bench_mini.py
@@ -1,7 +1,7 @@
 """Benchmarks for a minimal model instance."""
 from typing import TypedDict
 
-from optiframe import Optimizer, InfeasibleError
+from optiframe import InfeasibleError, Optimizer
 from optiframe.framework import InitializedOptimizer
 from pulp import LpMinimize
 

--- a/benches/utils/__init__.py
+++ b/benches/utils/__init__.py
@@ -1,5 +1,5 @@
 """Utility functions for the benchmark tool."""
-from typing import Callable, Any
+from typing import Any, Callable
 
 from optiframe import InfeasibleError, StepData
 from optiframe.framework import InitializedOptimizer

--- a/benches/utils/cli.py
+++ b/benches/utils/cli.py
@@ -1,7 +1,7 @@
 """Utility functions for the CLI usage of the benchmark tool."""
 from typing import Any
 
-from cloud_resource_matcher.solver import get_pulp_solver, Solver
+from cloud_resource_matcher.solver import Solver, get_pulp_solver
 
 
 def get_solver_from_args() -> Any:

--- a/benches/utils/data_generation.py
+++ b/benches/utils/data_generation.py
@@ -1,5 +1,5 @@
 """Utility functions to generate the benchmark data."""
-from cloud_resource_matcher.modules.base.data import CloudService, BaseData, CloudResource
+from cloud_resource_matcher.modules.base.data import BaseData, CloudResource, CloudService
 from cloud_resource_matcher.modules.network import NetworkData
 from cloud_resource_matcher.modules.network.data import Location
 

--- a/benches/utils/formatting.py
+++ b/benches/utils/formatting.py
@@ -2,7 +2,7 @@
 from datetime import timedelta
 
 from optiframe import StepData
-from optiframe.framework import StepTimes, ModelSize
+from optiframe.framework import ModelSize, StepTimes
 
 
 def print_result(instance: str, solution: StepData) -> None:

--- a/benches/utils/plot.py
+++ b/benches/utils/plot.py
@@ -1,11 +1,9 @@
 """Utility functions to plot the benchmark results."""
+import matplotlib.pyplot as plt
 from optiframe import StepData
 from optiframe.framework import ModelSize, StepTimes
 
-import matplotlib.pyplot as plt
-
-from benches.utils.results import get_total_time, get_model_size
-
+from benches.utils.results import get_model_size, get_total_time
 
 LINE_WIDTH = 3
 

--- a/benches/utils/results.py
+++ b/benches/utils/results.py
@@ -1,7 +1,7 @@
 """Utility methods for the benchmark results."""
 from datetime import timedelta
 
-from optiframe.framework import StepTimes, ModelSize
+from optiframe.framework import ModelSize, StepTimes
 
 
 def get_total_time(step_times: StepTimes) -> timedelta:

--- a/cloud_resource_matcher/modules/base/__init__.py
+++ b/cloud_resource_matcher/modules/base/__init__.py
@@ -6,11 +6,12 @@ and which cloud services are available.
 
 This module isn't very useful on its own, but provides the basis for all other modules.
 """
-from .data import BaseData
-from .validate import ValidateBaseTask
-from .build_mip import BuildMipBaseTask, BaseMipData
-from .extract_solution import ExtractSolutionBaseTask, BaseSolution
 from optiframe.framework import OptimizationModule
+
+from .build_mip import BaseMipData, BuildMipBaseTask
+from .data import BaseData
+from .extract_solution import BaseSolution, ExtractSolutionBaseTask
+from .validate import ValidateBaseTask
 
 base_module = OptimizationModule(
     validate=ValidateBaseTask, build_mip=BuildMipBaseTask, extract_solution=ExtractSolutionBaseTask

--- a/cloud_resource_matcher/modules/base/build_mip.py
+++ b/cloud_resource_matcher/modules/base/build_mip.py
@@ -2,9 +2,9 @@
 from dataclasses import dataclass
 
 from optiframe.framework.tasks import BuildMipTask
-from pulp import LpVariable, LpProblem, LpBinary, lpSum
+from pulp import LpBinary, LpProblem, LpVariable, lpSum
 
-from .data import BaseData, CloudService, CloudResource
+from .data import BaseData, CloudResource, CloudService
 
 VarCrToCsMatching = dict[tuple[CloudResource, CloudService], LpVariable]
 CsToCrList = dict[CloudService, set[CloudResource]]

--- a/cloud_resource_matcher/modules/base/data.py
+++ b/cloud_resource_matcher/modules/base/data.py
@@ -1,7 +1,6 @@
 """The data for the base module."""
 from dataclasses import dataclass
 
-
 # Any resource that needs to be deployed to the cloud (e.g. virtual machines).
 # Often abbreviated as 'CR'.
 CloudResource = str

--- a/cloud_resource_matcher/modules/base/extract_solution.py
+++ b/cloud_resource_matcher/modules/base/extract_solution.py
@@ -4,8 +4,8 @@ from dataclasses import dataclass
 from optiframe.framework.tasks import ExtractSolutionTask
 from pulp import pulp
 
-from .data import BaseData, CloudService, CloudResource
 from .build_mip import BaseMipData
+from .data import BaseData, CloudResource, CloudService
 
 CrToCsMatching = dict[tuple[CloudResource, CloudService], int]
 ServiceInstanceCount = dict[CloudService, int]

--- a/cloud_resource_matcher/modules/multi_cloud/__init__.py
+++ b/cloud_resource_matcher/modules/multi_cloud/__init__.py
@@ -4,10 +4,11 @@ This module can be used when multiple cloud service providers are considered for
 A minimum and maximum number of used CSPs can be enforced.
 Migration costs for the CSPs can also be represented.
 """
+from optiframe.framework import OptimizationModule
+
+from .build_mip import BuildMipMultiCloudTask, MultiCloudMipData
 from .data import MultiCloudData
 from .validate import ValidateMultiCloudTask
-from .build_mip import BuildMipMultiCloudTask, MultiCloudMipData
-from optiframe.framework import OptimizationModule
 
 multi_cloud_module = OptimizationModule(
     validate=ValidateMultiCloudTask, build_mip=BuildMipMultiCloudTask

--- a/cloud_resource_matcher/modules/multi_cloud/build_mip.py
+++ b/cloud_resource_matcher/modules/multi_cloud/build_mip.py
@@ -2,10 +2,11 @@
 from dataclasses import dataclass
 
 from optiframe.framework.tasks import BuildMipTask
-from pulp import LpProblem, LpBinary, LpVariable, lpSum
+from pulp import LpBinary, LpProblem, LpVariable, lpSum
 
-from .data import MultiCloudData, CloudServiceProvider
 from cloud_resource_matcher.modules.base import BaseData, BaseMipData
+
+from .data import CloudServiceProvider, MultiCloudData
 
 
 @dataclass

--- a/cloud_resource_matcher/modules/multi_cloud/data.py
+++ b/cloud_resource_matcher/modules/multi_cloud/data.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 
 from cloud_resource_matcher.modules.base.data import CloudService, Cost
 
-
 # The identifier for a cloud service provider such as AWS, Google Cloud or Azure.
 # Commonly abbreviated as 'CSP'.
 CloudServiceProvider = str

--- a/cloud_resource_matcher/modules/multi_cloud/validate.py
+++ b/cloud_resource_matcher/modules/multi_cloud/validate.py
@@ -2,6 +2,7 @@
 from optiframe.framework.tasks import ValidateTask
 
 from cloud_resource_matcher.modules.base import BaseData
+
 from .data import MultiCloudData
 
 

--- a/cloud_resource_matcher/modules/network/__init__.py
+++ b/cloud_resource_matcher/modules/network/__init__.py
@@ -3,11 +3,12 @@
 This module can be used to represent network connections,
 enforce maximum latency requirements and specify network usage costs.
 """
+from optiframe.framework import OptimizationModule
+
+from .build_mip import BuildMipNetworkTask, NetworkMipData
 from .data import NetworkData
 from .pre_processing import PreProcessingNetworkTask
 from .validate import ValidateNetworkTask
-from .build_mip import BuildMipNetworkTask, NetworkMipData
-from optiframe.framework import OptimizationModule
 
 network_module = OptimizationModule(
     validate=ValidateNetworkTask,

--- a/cloud_resource_matcher/modules/network/build_mip.py
+++ b/cloud_resource_matcher/modules/network/build_mip.py
@@ -2,11 +2,12 @@
 from dataclasses import dataclass
 
 from optiframe.framework.tasks import BuildMipTask
-from pulp import LpProblem, LpBinary, LpVariable, lpSum
+from pulp import LpBinary, LpProblem, LpVariable, lpSum
 
-from .data import NetworkData
-from ..base.data import CloudService, CloudResource
 from cloud_resource_matcher.modules.base import BaseData, BaseMipData
+
+from ..base.data import CloudResource, CloudService
+from .data import NetworkData
 
 
 @dataclass

--- a/cloud_resource_matcher/modules/network/build_mip.py
+++ b/cloud_resource_matcher/modules/network/build_mip.py
@@ -5,8 +5,8 @@ from optiframe.framework.tasks import BuildMipTask
 from pulp import LpBinary, LpProblem, LpVariable, lpSum
 
 from cloud_resource_matcher.modules.base import BaseData, BaseMipData
+from cloud_resource_matcher.modules.base.data import CloudResource, CloudService
 
-from ..base.data import CloudResource, CloudService
 from .data import NetworkData
 
 

--- a/cloud_resource_matcher/modules/network/data.py
+++ b/cloud_resource_matcher/modules/network/data.py
@@ -1,7 +1,7 @@
 """The data for the network module."""
 from dataclasses import dataclass
 
-from cloud_resource_matcher.modules.base.data import CloudService, CloudResource, Cost
+from cloud_resource_matcher.modules.base.data import CloudResource, CloudService, Cost
 
 Location = str
 Latency = int

--- a/cloud_resource_matcher/modules/network/validate.py
+++ b/cloud_resource_matcher/modules/network/validate.py
@@ -2,6 +2,7 @@
 from optiframe.framework.tasks import ValidateTask
 
 from cloud_resource_matcher.modules.base import BaseData
+
 from .data import NetworkData
 
 

--- a/cloud_resource_matcher/modules/performance/__init__.py
+++ b/cloud_resource_matcher/modules/performance/__init__.py
@@ -3,11 +3,12 @@
 This module can be used to enforce performance requirements
 and to represent usage-based pricing models.
 """
+from optiframe.framework import OptimizationModule
+
+from .build_mip import BuildMipPerformanceTask
 from .data import PerformanceData
 from .pre_processing import PreProcessingPerformanceTask
 from .validate import ValidatePerformanceTask
-from .build_mip import BuildMipPerformanceTask
-from optiframe.framework import OptimizationModule
 
 performance_module = OptimizationModule(
     validate=ValidatePerformanceTask,

--- a/cloud_resource_matcher/modules/performance/build_mip.py
+++ b/cloud_resource_matcher/modules/performance/build_mip.py
@@ -3,7 +3,8 @@ from optiframe.framework.tasks import BuildMipTask
 from pulp import LpProblem, lpSum
 
 from cloud_resource_matcher.modules.base import BaseData, BaseMipData
-from cloud_resource_matcher.modules.performance import PerformanceData
+
+from .data import PerformanceData
 
 
 class BuildMipPerformanceTask(BuildMipTask[None]):

--- a/cloud_resource_matcher/modules/performance/data.py
+++ b/cloud_resource_matcher/modules/performance/data.py
@@ -1,7 +1,7 @@
 """The data for the performance module."""
 from dataclasses import dataclass
 
-from cloud_resource_matcher.modules.base.data import CloudService, CloudResource, Cost
+from cloud_resource_matcher.modules.base.data import CloudResource, CloudService, Cost
 
 PerformanceCriterion = str
 

--- a/cloud_resource_matcher/modules/performance/pre_processing.py
+++ b/cloud_resource_matcher/modules/performance/pre_processing.py
@@ -2,7 +2,8 @@
 from optiframe.framework.tasks import PreProcessingTask
 
 from cloud_resource_matcher.modules.base import BaseData
-from cloud_resource_matcher.modules.performance import PerformanceData
+
+from .data import PerformanceData
 
 
 class PreProcessingPerformanceTask(PreProcessingTask[BaseData]):

--- a/cloud_resource_matcher/modules/performance/validate.py
+++ b/cloud_resource_matcher/modules/performance/validate.py
@@ -2,6 +2,7 @@
 from optiframe.framework.tasks import ValidateTask
 
 from cloud_resource_matcher.modules.base import BaseData
+
 from .data import PerformanceData
 
 

--- a/cloud_resource_matcher/modules/service_limits/__init__.py
+++ b/cloud_resource_matcher/modules/service_limits/__init__.py
@@ -3,10 +3,11 @@
 This module enables the number of instances for cloud services to be restricted.
 This can be helpful to represent popular regions where the servers are at capacity.
 """
+from optiframe.framework import OptimizationModule
+
+from .build_mip import BuildMipServiceLimitsTask
 from .data import ServiceLimitsData
 from .validate import ValidateServiceLimitsTask
-from .build_mip import BuildMipServiceLimitsTask
-from optiframe.framework import OptimizationModule
 
 service_limits_module = OptimizationModule(
     validate=ValidateServiceLimitsTask, build_mip=BuildMipServiceLimitsTask

--- a/cloud_resource_matcher/modules/service_limits/build_mip.py
+++ b/cloud_resource_matcher/modules/service_limits/build_mip.py
@@ -4,6 +4,7 @@ from pulp import LpProblem, lpSum
 
 from cloud_resource_matcher.modules.base import BaseData, BaseMipData
 from cloud_resource_matcher.modules.base.build_mip import CsToCrList
+
 from .data import ServiceLimitsData
 
 

--- a/cloud_resource_matcher/modules/service_limits/validate.py
+++ b/cloud_resource_matcher/modules/service_limits/validate.py
@@ -2,6 +2,7 @@
 from optiframe.framework.tasks import ValidateTask
 
 from cloud_resource_matcher.modules.base import BaseData
+
 from .data import ServiceLimitsData
 
 

--- a/cloud_resource_matcher/solver.py
+++ b/cloud_resource_matcher/solver.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 from enum import Enum
-from typing import Optional, Any
+from typing import Any, Optional
 
 import pulp
 

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -1,13 +1,13 @@
 """A demo for the cloud resource matcher."""
 from dataclasses import dataclass
-from datetime import timedelta, datetime
+from datetime import datetime, timedelta
 from typing import Optional
 
+from optiframe import InfeasibleError, Optimizer, SolutionObjValue
 from pulp import LpMinimize
 
+from cloud_resource_matcher.modules.base import BaseData, BaseSolution, base_module
 from cloud_resource_matcher.modules.base.data import Cost
-from optiframe import Optimizer, SolutionObjValue, InfeasibleError
-from cloud_resource_matcher.modules.base import BaseSolution, BaseData, base_module
 from cloud_resource_matcher.modules.multi_cloud import MultiCloudData, multi_cloud_module
 from cloud_resource_matcher.modules.network import NetworkData, network_module
 from cloud_resource_matcher.modules.performance import PerformanceData, performance_module
@@ -119,8 +119,8 @@ def solve_demo_model(
 
 def main() -> None:
     """Execute the demo for the cloud resource matcher."""
-    import logging
     import argparse
+    import logging
 
     logging.basicConfig(
         encoding="utf-8", level=logging.DEBUG, format="%(asctime)s [%(levelname)s] %(message)s"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ line-length = 100
 
 [tool.ruff]
 line-length = 100
-select = ["E", "F", "D"]
+select = ["E", "F", "D", "I"]
 ignore = [
     # multi-line-summary-second-line
     # Collides with other lint rule and is non-standard

--- a/test/case_studies/aws/test_aurora.py
+++ b/test/case_studies/aws/test_aurora.py
@@ -8,8 +8,8 @@ import pytest
 from optiframe import Optimizer, SolutionObjValue
 from pulp import LpMinimize, pulp
 
-from cloud_resource_matcher.modules.base import base_module, BaseData
-from cloud_resource_matcher.modules.performance import performance_module, PerformanceData
+from cloud_resource_matcher.modules.base import BaseData, base_module
+from cloud_resource_matcher.modules.performance import PerformanceData, performance_module
 
 OPTIMIZER = Optimizer("amazon_aurora", LpMinimize).add_modules(base_module, performance_module)
 

--- a/test/case_studies/aws/test_kinesis_data_analytics.py
+++ b/test/case_studies/aws/test_kinesis_data_analytics.py
@@ -8,8 +8,8 @@ import pytest
 from optiframe import Optimizer, SolutionObjValue
 from pulp import LpMinimize, pulp
 
-from cloud_resource_matcher.modules.base import base_module, BaseData
-from cloud_resource_matcher.modules.performance import performance_module, PerformanceData
+from cloud_resource_matcher.modules.base import BaseData, base_module
+from cloud_resource_matcher.modules.performance import PerformanceData, performance_module
 
 OPTIMIZER = Optimizer("amazon_kinesis_data_analytics", LpMinimize).add_modules(
     base_module, performance_module

--- a/test/case_studies/aws/test_lambda.py
+++ b/test/case_studies/aws/test_lambda.py
@@ -8,8 +8,8 @@ import pytest
 from optiframe import Optimizer, SolutionObjValue
 from pulp import LpMinimize, pulp
 
-from cloud_resource_matcher.modules.base import base_module, BaseData
-from cloud_resource_matcher.modules.performance import performance_module, PerformanceData
+from cloud_resource_matcher.modules.base import BaseData, base_module
+from cloud_resource_matcher.modules.performance import PerformanceData, performance_module
 
 OPTIMIZER = Optimizer("aws_lambda", LpMinimize).add_modules(base_module, performance_module)
 

--- a/test/case_studies/aws/test_s3.py
+++ b/test/case_studies/aws/test_s3.py
@@ -8,8 +8,8 @@ import pytest
 from optiframe import Optimizer, SolutionObjValue
 from pulp import LpMinimize, pulp
 
-from cloud_resource_matcher.modules.base import base_module, BaseData
-from cloud_resource_matcher.modules.performance import performance_module, PerformanceData
+from cloud_resource_matcher.modules.base import BaseData, base_module
+from cloud_resource_matcher.modules.performance import PerformanceData, performance_module
 
 OPTIMIZER = Optimizer("amazon_s3", LpMinimize).add_modules(base_module, performance_module)
 

--- a/test/case_studies/google_cloud/test_storage.py
+++ b/test/case_studies/google_cloud/test_storage.py
@@ -9,9 +9,9 @@ import pytest
 from optiframe import Optimizer, SolutionObjValue
 from pulp import LpMinimize, pulp
 
-from cloud_resource_matcher.modules.base import base_module, BaseData
-from cloud_resource_matcher.modules.network import network_module, NetworkData
-from cloud_resource_matcher.modules.performance import performance_module, PerformanceData
+from cloud_resource_matcher.modules.base import BaseData, base_module
+from cloud_resource_matcher.modules.network import NetworkData, network_module
+from cloud_resource_matcher.modules.performance import PerformanceData, performance_module
 
 OPTIMIZER = Optimizer("google_cloud_storage", LpMinimize).add_modules(
     base_module, performance_module, network_module

--- a/test/case_studies/microsoft_azure/test_functions.py
+++ b/test/case_studies/microsoft_azure/test_functions.py
@@ -8,8 +8,8 @@ import pytest
 from optiframe import Optimizer, SolutionObjValue
 from pulp import LpMinimize, pulp
 
-from cloud_resource_matcher.modules.base import base_module, BaseData
-from cloud_resource_matcher.modules.performance import performance_module, PerformanceData
+from cloud_resource_matcher.modules.base import BaseData, base_module
+from cloud_resource_matcher.modules.performance import PerformanceData, performance_module
 
 OPTIMIZER = Optimizer("azure_functions", LpMinimize).add_modules(base_module, performance_module)
 

--- a/test/framework.py
+++ b/test/framework.py
@@ -3,19 +3,19 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from typing import Self, Optional, Dict, List, Iterable
+from typing import Dict, Iterable, List, Optional, Self
 
 import pytest
-from pulp import LpVariable, LpProblem
+from optiframe import InfeasibleError, SolutionObjValue
+from optiframe.framework import BuiltOptimizer, InitializedOptimizer
+from pulp import LpProblem, LpVariable
 
-from optiframe.framework import InitializedOptimizer, BuiltOptimizer
 from cloud_resource_matcher.modules.base import BaseSolution
+from cloud_resource_matcher.modules.base.data import CloudResource, CloudService, Cost
 from cloud_resource_matcher.modules.base.extract_solution import (
     CrToCsMatching,
     ServiceInstanceCount,
 )
-from optiframe import SolutionObjValue, InfeasibleError
-from cloud_resource_matcher.modules.base.data import CloudService, CloudResource, Cost
 
 
 @dataclass

--- a/test/modules/base/test_build_mip.py
+++ b/test/modules/base/test_build_mip.py
@@ -1,9 +1,10 @@
 """Tests for the build MIP step of the base module."""
+from test.framework import Expect
+
 from optiframe import Optimizer
 from pulp import LpMinimize
 
 from cloud_resource_matcher.modules.base import BaseData, base_module
-from test.framework import Expect
 
 OPTIMIZER = Optimizer("test_base", sense=LpMinimize).add_modules(base_module)
 

--- a/test/modules/multi_cloud/test_build_mip.py
+++ b/test/modules/multi_cloud/test_build_mip.py
@@ -1,11 +1,11 @@
 """Tests for the build MIP step of the multi cloud module."""
+from test.framework import Expect
+
 from optiframe import Optimizer
 from pulp import LpMinimize
 
 from cloud_resource_matcher.modules.base import BaseData, base_module
 from cloud_resource_matcher.modules.multi_cloud import MultiCloudData, multi_cloud_module
-from test.framework import Expect
-
 
 OPTIMIZER = Optimizer("test_multi_cloud", sense=LpMinimize).add_modules(
     base_module, multi_cloud_module

--- a/test/modules/network/test_build_mip.py
+++ b/test/modules/network/test_build_mip.py
@@ -1,11 +1,11 @@
 """Tests for the build MIP step of the network module."""
+from test.framework import Expect
+
 from optiframe import Optimizer
 from pulp import LpMinimize
 
 from cloud_resource_matcher.modules.base import BaseData, base_module
 from cloud_resource_matcher.modules.network import NetworkData, network_module
-from test.framework import Expect
-
 
 OPTIMIZER = Optimizer("test_network", sense=LpMinimize).add_modules(base_module, network_module)
 

--- a/test/modules/performance/test_build_mip.py
+++ b/test/modules/performance/test_build_mip.py
@@ -1,12 +1,12 @@
 """Tests for the build MIP step of the performance module."""
+from test.framework import Expect
+
 from optiframe import Optimizer
 from pulp import LpMinimize
 
 from cloud_resource_matcher.modules.base import BaseData, base_module
 from cloud_resource_matcher.modules.performance import PerformanceData, performance_module
-from cloud_resource_matcher.modules.service_limits import service_limits_module, ServiceLimitsData
-from test.framework import Expect
-
+from cloud_resource_matcher.modules.service_limits import ServiceLimitsData, service_limits_module
 
 OPTIMIZER = Optimizer("test_performance", sense=LpMinimize).add_modules(
     base_module, performance_module

--- a/test/modules/service_limits/test_build_mip.py
+++ b/test/modules/service_limits/test_build_mip.py
@@ -1,10 +1,11 @@
 """Tests for the build MIP step of the service limits module."""
+from test.framework import Expect
+
 from optiframe import Optimizer
 from pulp import LpMinimize
 
 from cloud_resource_matcher.modules.base import BaseData, base_module
-from cloud_resource_matcher.modules.service_limits import service_limits_module, ServiceLimitsData
-from test.framework import Expect
+from cloud_resource_matcher.modules.service_limits import ServiceLimitsData, service_limits_module
 
 OPTIMIZER = Optimizer("test_service_limits", sense=LpMinimize).add_modules(
     base_module, service_limits_module


### PR DESCRIPTION
Closes #13.

Enable the `I` class of errors for ruff to enforce sorted imports.