### PR TITLE
Simplify matching in base solution

### DIFF
--- a/cloud_resource_matcher/modules/base/solution_extraction.py
+++ b/cloud_resource_matcher/modules/base/solution_extraction.py
@@ -7,7 +7,7 @@ from pulp import pulp
 from .data import BaseData, CloudResource, CloudService
 from .mip_construction import BaseMipData
 
-CrToCsMatching = dict[tuple[CloudResource, CloudService], int]
+CrToCsMatching = dict[CloudResource, CloudService]
 ServiceInstanceCount = dict[CloudService, int]
 
 
@@ -45,13 +45,10 @@ class SolutionExtractionBaseTask(SolutionExtractionTask[BaseSolution]):
 
         for cr in self.base_data.cloud_resources:
             for cs in self.base_data.cr_to_cs_list[cr]:
-                value = (
-                    round(pulp.value(self.base_mip_data.var_cr_to_cs_matching[cr, cs]))
-                    * self.base_data.cr_to_instance_demand[cr]
-                )
+                value = round(pulp.value(self.base_mip_data.var_cr_to_cs_matching[cr, cs]))
 
                 if value >= 1:
-                    cr_to_cs_matching[cr, cs] = value
+                    cr_to_cs_matching[cr] = cs
 
         cs_instance_count: ServiceInstanceCount = {}
 

--- a/test/modules/base/test_build_mip.py
+++ b/test/modules/base/test_build_mip.py
@@ -21,9 +21,7 @@ def test_one_cr_one_cs_trivial_solution() -> None:
         )
     )
 
-    Expect(optimizer).to_be_feasible().with_cost(5).with_cr_to_cs_matching(
-        {("cr_0", "cs_0"): 1}
-    ).test()
+    Expect(optimizer).to_be_feasible().with_cost(5).with_cr_to_cs_matching({"cr_0": "cs_0"}).test()
 
 
 def test_only_one_valid_matching() -> None:
@@ -41,7 +39,7 @@ def test_only_one_valid_matching() -> None:
     )
 
     Expect(optimizer).to_be_feasible().with_cr_to_cs_matching(
-        {(f"cr_{i}", f"cs_{i}"): 1 for i in range(count)}
+        {f"cr_{i}": f"cs_{i}" for i in range(count)}
     ).test()
 
 

--- a/test/modules/multi_cloud/test_build_mip.py
+++ b/test/modules/multi_cloud/test_build_mip.py
@@ -39,7 +39,7 @@ def test_min_csp_count_constraint_matching() -> None:
     )
 
     Expect(optimizer).to_be_feasible().with_cost(11).with_cr_to_cs_matching(
-        {("cr_0", "cs_0"): 1, ("cr_1", "cs_2"): 1}
+        {"cr_0": "cs_0", "cr_1": "cs_2"}
     ).with_variable_values({"csp_used(csp_0)": 1, "csp_used(csp_1)": 1}).test()
 
 
@@ -70,7 +70,7 @@ def test_max_csp_count_constraint_matching() -> None:
     )
 
     Expect(optimizer).to_be_feasible().with_cost(20).with_cr_to_cs_matching(
-        {("cr_0", "cs_0"): 1, ("cr_1", "cs_1"): 1}
+        {"cr_0": "cs_0", "cr_1": "cs_1"}
     ).with_variable_values({"csp_used(csp_0)": 1, "csp_used(csp_1)": 0}).test()
 
 
@@ -140,6 +140,4 @@ def test_csp_objective() -> None:
         ),
     )
 
-    Expect(optimizer).to_be_feasible().with_cost(11).with_cr_to_cs_matching(
-        {("cr_0", "cs_0"): 1}
-    ).test()
+    Expect(optimizer).to_be_feasible().with_cost(11).with_cr_to_cs_matching({"cr_0": "cs_0"}).test()

--- a/test/modules/network/test_build_mip.py
+++ b/test/modules/network/test_build_mip.py
@@ -100,7 +100,7 @@ def test_should_choose_matching_that_respects_max_latency() -> None:
         ),
     )
 
-    Expect(optimizer).to_be_feasible().with_cr_to_cs_matching({("cr_0", "cs_0"): 1}).test()
+    Expect(optimizer).to_be_feasible().with_cr_to_cs_matching({"cr_0": "cs_0"}).test()
 
 
 def test_should_calculate_service_deployments_for_cr_pairs() -> None:
@@ -135,7 +135,7 @@ def test_should_calculate_service_deployments_for_cr_pairs() -> None:
     )
 
     Expect(optimizer).to_be_feasible().with_cr_to_cs_matching(
-        {("cr_0", "cs_0"): 1, ("cr_1", "cs_1"): 3}
+        {"cr_0": "cs_0", "cr_1": "cs_1"}
     ).with_variable_values(
         {
             "cr_pair_cs_deployment(cr_0,cs_0,cr_1,cs_1)": 1,

--- a/test/modules/performance/test_build_mip.py
+++ b/test/modules/performance/test_build_mip.py
@@ -92,7 +92,7 @@ def test_resource_matching() -> None:
     )
 
     Expect(optimizer).to_be_feasible().with_cr_to_cs_matching(
-        {(f"cr_{i}", f"cs_{i}"): 1 for i in range(count)}
+        {f"cr_{i}": f"cs_{i}" for i in range(count)}
     ).test()
 
 
@@ -115,9 +115,7 @@ def test_cheap_insufficient_cs() -> None:
         ),
     )
 
-    Expect(optimizer).to_be_feasible().with_cr_to_cs_matching({("cr_0", "cs_1"): 1}).with_cost(
-        10
-    ).test()
+    Expect(optimizer).to_be_feasible().with_cr_to_cs_matching({"cr_0": "cs_1"}).with_cost(10).test()
 
 
 def test_allowed_incomplete_data() -> None:
@@ -160,7 +158,7 @@ def test_should_work_with_higher_cr_and_time_to_instance_demand() -> None:
         ),
     )
 
-    Expect(optimizer).to_be_feasible().with_cr_to_cs_matching({("cr_0", "cs_0"): 2})
+    Expect(optimizer).to_be_feasible().with_cr_to_cs_matching({"cr_0": "cs_0"})
 
 
 def test_should_be_infeasible_if_not_enough_cs_instances_can_be_bought() -> None:

--- a/test/modules/service_limits/test_build_mip.py
+++ b/test/modules/service_limits/test_build_mip.py
@@ -25,9 +25,7 @@ def test_one_cr_one_cs_trivial_solution() -> None:
         ServiceLimitsData(cs_to_instance_limit={"cs_0": 1}, cr_to_max_instance_demand={"cr_0": 1}),
     )
 
-    Expect(optimizer).to_be_feasible().with_cost(5).with_cr_to_cs_matching(
-        {("cr_0", "cs_0"): 1}
-    ).test()
+    Expect(optimizer).to_be_feasible().with_cost(5).with_cr_to_cs_matching({"cr_0": "cs_0"}).test()
 
 
 def test_infeasible_not_enough_cs_instances() -> None:


### PR DESCRIPTION
Closes #19.

This PR simplifies the `cr_to_cs_matching` in `BaseSolution` to make it easier to understand and use.

It's now a simple `dict` from the cloud resources to the cloud services they are deployed on.