### PR TITLE
Add dark theme benchmarks

### DIFF
--- a/benches/utils/__init__.py
+++ b/benches/utils/__init__.py
@@ -42,4 +42,4 @@ def setup_benchmark(
         with open(f"benches/output/json/{param_name}.json", "w+") as file:
             json.dump(results, file, indent=2)
 
-    plot_results(results)
+    plot_results(results, dark_theme=args.dark_theme)

--- a/benches/utils/__init__.py
+++ b/benches/utils/__init__.py
@@ -23,6 +23,7 @@ def setup_benchmark(
     # Create directories if they don't exist
     os.makedirs("benches/output/pdf", exist_ok=True)
     os.makedirs("benches/output/png", exist_ok=True)
+    os.makedirs("benches/output/svg", exist_ok=True)
     os.makedirs("benches/output/json", exist_ok=True)
 
     if args.use_cache:

--- a/benches/utils/cli.py
+++ b/benches/utils/cli.py
@@ -12,6 +12,7 @@ class CliArgs:
     solver: Any
     measures: int
     use_cache: bool
+    dark_theme: bool
 
 
 def get_cli_args() -> CliArgs:
@@ -37,6 +38,12 @@ def get_cli_args() -> CliArgs:
         default=False,
         help="Use the cached JSON measurements, only regenerate the plots.",
     )
+    parser.add_argument(
+        "--dark-theme",
+        action="store_true",
+        default=False,
+        help="Use a dark theme for the generated plots.",
+    )
 
     args = parser.parse_args()
 
@@ -55,4 +62,5 @@ def get_cli_args() -> CliArgs:
         solver=get_pulp_solver(solver=solver, msg=False),
         measures=args.measures,
         use_cache=args.use_cache,
+        dark_theme=args.dark_theme,
     )

--- a/benches/utils/plot.py
+++ b/benches/utils/plot.py
@@ -1,12 +1,14 @@
 """Utility functions to plot the benchmark results."""
 import matplotlib.pyplot as plt
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
 
 from benches.utils.run import BenchmarkResult
 
 LINE_WIDTH = 3
 
 
-def plot_results(result: BenchmarkResult) -> None:
+def plot_results(result: BenchmarkResult, dark_theme: bool = True) -> None:
     """Create a line graph for the benchmark results."""
     model_sizes: list[int] = [
         measure["variable_count"] * measure["constraint_count"] for measure in result["measures"]
@@ -17,11 +19,17 @@ def plot_results(result: BenchmarkResult) -> None:
         for measure in result["measures"]
     ]
 
-    col_model_size = "black"
-    col_optimization_time = "gray"
+    # Colors
+    col_background = "#121212" if dark_theme else "white"
+    col_text = "white" if dark_theme else "black"
+    col_lines = col_text
+    col_model_size = "#93bce1" if dark_theme else "black"
+    col_optimization_time = "#b993e1" if dark_theme else "gray"
 
+    fig: Figure
+    ax: Axes
     fig, ax = plt.subplots()
-    ax.set_xlabel(result["variation_name"])
+    ax.set_xlabel(result["variation_name"], color=col_text)
 
     # Model size plot
     (size_plot,) = ax.plot(
@@ -33,10 +41,17 @@ def plot_results(result: BenchmarkResult) -> None:
         linewidth=LINE_WIDTH,
     )
     ax.set_ylim(bottom=0)
-    ax.set_ylabel("model size")
+    ax.set_ylabel("model size", color=col_text)
+
+    ax.patch.set_facecolor(col_background)
+    ax.xaxis.set_tick_params(color=col_lines, labelcolor=col_lines)
+    ax.yaxis.set_tick_params(color=col_lines, labelcolor=col_lines)
+
+    for spine in ax.spines.values():
+        spine.set_edgecolor(col_lines)
 
     # Optimization time plot
-    ax2 = ax.twinx()
+    ax2: Axes = ax.twinx()
     (time_plot,) = ax2.plot(
         result["param_values"],
         optimization_times,
@@ -46,10 +61,24 @@ def plot_results(result: BenchmarkResult) -> None:
         linewidth=LINE_WIDTH,
     )
     ax2.set_ylim(bottom=0)
-    ax2.set_ylabel("total optimization time (s)")
+    ax2.set_ylabel("total optimization time (s)", color=col_text)
+
+    ax2.patch.set_facecolor(col_background)
+    ax2.xaxis.set_tick_params(color=col_lines, labelcolor=col_lines)
+    ax2.yaxis.set_tick_params(color=col_lines, labelcolor=col_lines)
+
+    for spine in ax2.spines.values():
+        spine.set_edgecolor(col_lines)
 
     # Legend
-    ax.legend(handles=[size_plot, time_plot])
+    ax.legend(
+        handles=[size_plot, time_plot],
+        labelcolor=col_text,
+        edgecolor=col_lines,
+        facecolor=col_background,
+    )
+
+    fig.patch.set_facecolor(col_background)
 
     # Save the plot
     fig.savefig(f"benches/output/png/{result['param_name']}.png")

--- a/benches/utils/plot.py
+++ b/benches/utils/plot.py
@@ -8,7 +8,7 @@ from benches.utils.run import BenchmarkResult
 LINE_WIDTH = 3
 
 
-def plot_results(result: BenchmarkResult, dark_theme: bool = True) -> None:
+def plot_results(result: BenchmarkResult, dark_theme: bool = False) -> None:
     """Create a line graph for the benchmark results."""
     model_sizes: list[int] = [
         measure["variable_count"] * measure["constraint_count"] for measure in result["measures"]

--- a/benches/utils/plot.py
+++ b/benches/utils/plot.py
@@ -54,3 +54,4 @@ def plot_results(result: BenchmarkResult) -> None:
     # Save the plot
     fig.savefig(f"benches/output/png/{result['param_name']}.png")
     fig.savefig(f"benches/output/pdf/{result['param_name']}.pdf")
+    fig.savefig(f"benches/output/svg/{result['param_name']}.svg")

--- a/benches/utils/plot.py
+++ b/benches/utils/plot.py
@@ -21,15 +21,14 @@ def plot_results(result: BenchmarkResult, dark_theme: bool = False) -> None:
 
     # Colors
     col_background = "#121212" if dark_theme else "white"
-    col_text = "white" if dark_theme else "black"
-    col_lines = col_text
+    col_foreground = "white" if dark_theme else "black"
     col_model_size = "#93bce1" if dark_theme else "black"
     col_optimization_time = "#b993e1" if dark_theme else "gray"
 
     fig: Figure
     ax: Axes
     fig, ax = plt.subplots()
-    ax.set_xlabel(result["variation_name"], color=col_text)
+    ax.set_xlabel(result["variation_name"], color=col_foreground)
 
     # Model size plot
     (size_plot,) = ax.plot(
@@ -40,15 +39,8 @@ def plot_results(result: BenchmarkResult, dark_theme: bool = False) -> None:
         marker="o",
         linewidth=LINE_WIDTH,
     )
-    ax.set_ylim(bottom=0)
-    ax.set_ylabel("model size", color=col_text)
 
-    ax.patch.set_facecolor(col_background)
-    ax.xaxis.set_tick_params(color=col_lines, labelcolor=col_lines)
-    ax.yaxis.set_tick_params(color=col_lines, labelcolor=col_lines)
-
-    for spine in ax.spines.values():
-        spine.set_edgecolor(col_lines)
+    configure_axes(ax, "model size", col_background, col_foreground)
 
     # Optimization time plot
     ax2: Axes = ax.twinx()
@@ -60,21 +52,14 @@ def plot_results(result: BenchmarkResult, dark_theme: bool = False) -> None:
         marker="v",
         linewidth=LINE_WIDTH,
     )
-    ax2.set_ylim(bottom=0)
-    ax2.set_ylabel("total optimization time (s)", color=col_text)
 
-    ax2.patch.set_facecolor(col_background)
-    ax2.xaxis.set_tick_params(color=col_lines, labelcolor=col_lines)
-    ax2.yaxis.set_tick_params(color=col_lines, labelcolor=col_lines)
-
-    for spine in ax2.spines.values():
-        spine.set_edgecolor(col_lines)
+    configure_axes(ax2, "total optimization time (s)", col_background, col_foreground)
 
     # Legend
     ax.legend(
         handles=[size_plot, time_plot],
-        labelcolor=col_text,
-        edgecolor=col_lines,
+        labelcolor=col_foreground,
+        edgecolor=col_foreground,
         facecolor=col_background,
     )
 
@@ -84,3 +69,16 @@ def plot_results(result: BenchmarkResult, dark_theme: bool = False) -> None:
     fig.savefig(f"benches/output/png/{result['param_name']}.png")
     fig.savefig(f"benches/output/pdf/{result['param_name']}.pdf")
     fig.savefig(f"benches/output/svg/{result['param_name']}.svg")
+
+
+def configure_axes(axes: Axes, label: str, col_background: str, col_foreground: str) -> None:
+    """Configure common properties of an axes."""
+    axes.set_ylim(bottom=0)
+    axes.set_ylabel(label, color=col_foreground)
+
+    axes.patch.set_facecolor(col_background)
+    axes.xaxis.set_tick_params(color=col_foreground, labelcolor=col_foreground)
+    axes.yaxis.set_tick_params(color=col_foreground, labelcolor=col_foreground)
+
+    for spine in axes.spines.values():
+        spine.set_edgecolor(col_foreground)


### PR DESCRIPTION
Closes #24.

This PR adds a new CLI option to the benchmark script which allows you to generate images with a dark theme.

It also adds SVG exports of the benchmarks.